### PR TITLE
Add pagination support to Users.list method

### DIFF
--- a/slacker2/__init__.py
+++ b/slacker2/__init__.py
@@ -327,8 +327,8 @@ class Users(BaseAPI):
         return self.get('users.info',
                         params={'user': user, 'include_locale': include_locale})
 
-    def list(self, presence=False):
-        return self.get('users.list', params={'presence': int(presence)})
+    def list(self, cursor=None, presence=False):
+        return self.get('users.list', params={'presence': int(presence), 'cursor': cursor})
 
     def identity(self):
         return self.get('users.identity')

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -3,8 +3,8 @@
 import responses
 import unittest
 
-from slacker import Users
-from slacker.utilities import get_api_url
+from slacker2 import Users
+from slacker2.utilities import get_api_url
 
 
 class TestUsers(unittest.TestCase):

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,94 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+import responses
+import unittest
+
+from slacker import Users
+from slacker.utilities import get_api_url
+
+
+class TestUsers(unittest.TestCase):
+    @responses.activate
+    def test_user_list_supports_pagination(self):
+        response = {
+            "ok": True,
+            "members": [{
+                    "id": "id1",
+                    "team_id": "team_id1",
+                    "name": "vasya",
+                    "deleted": False,
+                    "real_name": "Vasya Pupkin",
+                    "profile": {
+                        "display_name": "vasya",
+                        "email": "v.pupkin@email.com",
+                        "team": "team_id1"
+                    },
+                    "is_admin": True
+                },
+                {
+                    "id": "id2",
+                    "team_id": "team_id2",
+                    "name": "petya",
+                    "deleted": False,
+                    "real_name": "Petya Pupkin",
+                    "profile": {
+                        "real_name": "Petya Pupkin",
+                        "email": "p.pupkin@email.com",
+                        "team": "team_id2"
+                    },
+                    "response_metadata": {
+                        "next_cursor": ""
+                    }
+                }]
+        }
+
+        responses.add(
+            responses.GET,
+            get_api_url('users.list?presence=0&cursor=next_cursor1'),
+            json=response,
+            status=200
+        )
+        users = Users()
+        users_list = users.list(cursor='next_cursor1')
+        self.assertEqual(len(users_list.body['members']), 2)
+
+    @responses.activate
+    def test_user_list_supports_pagination(self):
+        response = {
+            "ok": True,
+            "members": [{
+                "id": "id1",
+                "team_id": "team_id1",
+                "name": "vasya",
+                "deleted": False,
+                "real_name": "Vasya Pupkin",
+                "profile": {
+                    "display_name": "vasya",
+                    "email": "v.pupkin@email.com",
+                    "team": "team_id1"
+                },
+                "is_admin": True
+            },
+                {
+                    "id": "id2",
+                    "team_id": "team_id2",
+                    "name": "petya",
+                    "deleted": False,
+                    "real_name": "Petya Pupkin",
+                    "profile": {
+                        "real_name": "Petya Pupkin",
+                        "email": "p.pupkin@email.com",
+                        "team": "team_id2"
+                    }
+                }]
+        }
+
+        responses.add(
+            responses.GET,
+            get_api_url('users.list?presence=0'),
+            json=response,
+            status=200
+        )
+        users = Users()
+        users_list = users.list()
+        self.assertEqual(len(users_list.body['members']), 2)


### PR DESCRIPTION
As for now, Slack users.list API (https://api.slack.com/methods/users.list) would return only 1000 of users, even if pagination was not requested.

This PR is intended to extend Users.list method and support optional cursor parameter, which will make it possible to iterate over paginated response.

P.S. My initial idea was to make pagination implicit and hidden from user, but it would require to create artificial "joined" response from all the hidden requests and add some "black magic", which may result in a debug hell.