### PR TITLE
Blocks Support

### DIFF
--- a/slacker2/__init__.py
+++ b/slacker2/__init__.py
@@ -488,7 +488,8 @@ class Chat(BaseAPI):
     def post_message(self, channel, text=None, username=None, as_user=None,
                      parse=None, link_names=None, attachments=None,
                      unfurl_links=None, unfurl_media=None, icon_url=None,
-                     icon_emoji=None, thread_ts=None, reply_broadcast=None):
+                     icon_emoji=None, thread_ts=None, reply_broadcast=None,
+                     blocks=None):
 
         # Ensure attachments are json encoded
         if attachments:
@@ -509,12 +510,17 @@ class Chat(BaseAPI):
                              'icon_url': icon_url,
                              'icon_emoji': icon_emoji,
                              'thread_ts': thread_ts,
-                             'reply_broadcast': reply_broadcast
+                             'reply_broadcast': reply_broadcast,
+                             'blocks': blocks
                          })
 
-    def me_message(self, channel, text):
+    def me_message(self, channel, text, blocks):
         return self.post('chat.meMessage',
-                         data={'channel': channel, 'text': text})
+                         data={
+                             'channel': channel,
+                             'text': text,
+                             'blocks': blocks
+                         })
 
     def command(self, channel, command, text):
         return self.post('chat.command',
@@ -525,7 +531,7 @@ class Chat(BaseAPI):
                          })
 
     def update(self, channel, ts, text, attachments=None, parse=None,
-               link_names=False, as_user=None):
+               link_names=False, as_user=None, blocks=None):
         # Ensure attachments are json encoded
         if attachments is not None and isinstance(attachments, list):
             attachments = json.dumps(attachments)
@@ -538,6 +544,7 @@ class Chat(BaseAPI):
                              'parse': parse,
                              'link_names': int(link_names),
                              'as_user': as_user,
+                             'blocks': blocks
                          })
 
     def delete(self, channel, ts, as_user=False):
@@ -549,7 +556,8 @@ class Chat(BaseAPI):
                          })
 
     def post_ephemeral(self, channel, text, user, as_user=None,
-                       attachments=None, link_names=None, parse=None):
+                       attachments=None, link_names=None, parse=None,
+                       blocks=None):
         # Ensure attachments are json encoded
         if attachments is not None and isinstance(attachments, list):
             attachments = json.dumps(attachments)
@@ -562,6 +570,7 @@ class Chat(BaseAPI):
                              'attachments': attachments,
                              'link_names': link_names,
                              'parse': parse,
+                             'blocks': blocks
                          })
 
     def unfurl(self, channel, ts, unfurls, user_auth_message=None,


### PR DESCRIPTION
This commit adds support for message blocks.

Slack is moving towards this as the default method of posting
complex messages in future.

The blocks themselves are just another JSON object passed to the API, so
supporting them is simple.

This commit be @symroe was taken from
https://github.com/os/slacker/pull/152, but with a single commit
message. @genghis should get the credit for the initial work.