### PR TITLE
Drop python 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 dist: xenial
 
 python:
-  - "2.7"
   - "3.6"
   - "3.7"
   - "3.8-dev"


### PR DESCRIPTION
As per my comment in https://github.com/senpay/slacker/pull/2, I think it's reasonable to drop python2 support, rather than try to fix the failing CI build.